### PR TITLE
Add SetLogger(core.ILogger) to Engine Interface

### DIFF
--- a/orm/xorm/interface.go
+++ b/orm/xorm/interface.go
@@ -134,6 +134,7 @@ type Engine interface {
 	SetMaxIdleConns(int)
 	NoCache() *xorm.Session
 	NoCascade() *xorm.Session
+	SetLogger(core.ILogger)
 
 	NewSession() *xorm.Session
 	Close() error


### PR DESCRIPTION
Add xorm.engine.SetLogger() interface.

it is successful to go test `interface_test.go`.  Yeah.
